### PR TITLE
Set values in config.plist related to FileVault.

### DIFF
--- a/MY EFI/OC/config.plist
+++ b/MY EFI/OC/config.plist
@@ -630,7 +630,7 @@
 			<key>PickerMode</key>
 			<string>Builtin</string>
 			<key>PollAppleHotKeys</key>
-			<false/>
+			<true/>
 			<key>ShowPicker</key>
 			<true/>
 			<key>TakeoffDelay</key>
@@ -954,7 +954,7 @@
 			<key>AppleRtcRam</key>
 			<false/>
 			<key>AppleSmcIo</key>
-			<false/>
+			<true/>
 			<key>AppleUserInterfaceTheme</key>
 			<false/>
 			<key>DataHub</key>
@@ -962,7 +962,7 @@
 			<key>DeviceProperties</key>
 			<false/>
 			<key>FirmwareVolume</key>
-			<false/>
+			<true/>
 			<key>HashServices</key>
 			<false/>
 			<key>OSInfo</key>


### PR DESCRIPTION
The values are set according to the guide: https://dortania.github.io/OpenCore-Desktop-Guide/post-install/security.html

With this config, FileVault has been confirmed to function on the Aorus Pro Wifi with the i9-9900K.  I expect it would work similarly for the Aorus Master.